### PR TITLE
Use Case Insensitive String.Contains in CopyFilesRecursive function

### DIFF
--- a/AtomicLib/Core.cs
+++ b/AtomicLib/Core.cs
@@ -333,7 +333,7 @@ public static class Core
     {
         foreach (var file in source.GetFiles())
         {
-            if (!blacklist.Contains(file.Name))
+            if (!blacklist.Contains(file.Name, StringComparer.OrdinalIgnoreCase))
                 file.CopyTo(destination + "/" + file.Name);
         }
 


### PR DESCRIPTION
Fixes #13 