### PR TITLE
Update to dotnet 8.0

### DIFF
--- a/Atomic.Gtk/Atomic.Gtk.csproj
+++ b/Atomic.Gtk/Atomic.Gtk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <OutputType>WinExe</OutputType>
         <RollForward>LatestMajor</RollForward>

--- a/Atomic.Wpf/Atomic.Wpf.csproj
+++ b/Atomic.Wpf/Atomic.Wpf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0-windows</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <OutputType>WinExe</OutputType>
         <LangVersion>10</LangVersion>

--- a/Atomic/Atomic.csproj
+++ b/Atomic/Atomic.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <RollForward>LatestMajor</RollForward>
   </PropertyGroup>

--- a/AtomicLib/AtomicLib.csproj
+++ b/AtomicLib/AtomicLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <LangVersion>10</LangVersion>

--- a/AtomicLibTests/AtomicLibTests.csproj
+++ b/AtomicLibTests/AtomicLibTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
This PR upgrades all projects inside the Atomic solution to use net8.0  

Details:

> _Atomic.Gtk
> Atomic.Wpf
> AtomicLibTests_

Went from net6.0 to net8.0

> _Atomic
> AtomicLib_

Went from netstandard2.1 to net8.0

Atomic.Mac did not change as it was already using net8.0