### PR TITLE
Remove CurrentFilter from file picker dialog

### DIFF
--- a/Atomic/ModPacker.cs
+++ b/Atomic/ModPacker.cs
@@ -367,7 +367,6 @@ public partial class ModPacker : Form
         {
             Filters = { filter },
             Title = title,
-            CurrentFilter = filter,
             CheckFileExists = true,
         };
         if (fileFinder.ShowDialog(this) != DialogResult.Ok)


### PR DESCRIPTION
This PR removes the 'CurrentFilter' argument from the file picker dialog.
It's unnecessary since we only have on filter enabled each time (.zip or .apk) and it also breaks the file picker for Flatpak.